### PR TITLE
Automatically install bower once after npm installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "node_modules/.bin/bower install"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Durch diese Änderung wird automatisch `bower install` ausgeführt, nachdem man in der Konsole `npm install` gestartet hat. So muss man nicht immer zwei Schritte machen.