### PR TITLE
Fixed JS integration by adding a new gulp task for 'js'

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,19 @@
 var gulp = require('gulp');
 var sass = require('gulp-sass');
 var minifyHtml = require("gulp-minify-html");
+var concat = require("gulp-concat");
 var browserSync = require('browser-sync').create();
+
+gulp.task('js', function () {
+    return gulp.src([
+        './bower_components/jquery/dist/jquery.min.js',
+        './bower_components/materialize/dist/js/materialize.min.js',
+        './src/**/*.js'
+    ])
+        .pipe(concat('scripts.js'))
+        .pipe(gulp.dest('./dist'))
+        .pipe(browserSync.stream());
+});
 
 gulp.task('sass', function () {
     return gulp.src('./src/sass/style.scss')
@@ -10,8 +22,9 @@ gulp.task('sass', function () {
         .pipe(browserSync.stream());
 });
 
-gulp.task('watch', ['sass', 'html', 'browser-sync'], function () {
+gulp.task('watch', ['sass', 'js', 'html', 'browser-sync'], function () {
     gulp.watch(['./src/**/*.scss'], ['sass']);
+    gulp.watch(['./src/**/*.js'], ['js']);
     gulp.watch(['./src/*.html'], ['html']);
 
 });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "bower": "^1.8.0",
     "browser-sync": "^2.18.6",
     "gulp": "^3.9.1",
+    "gulp-concat": "^2.6.1",
     "gulp-minify-html": "^1.0.6",
     "gulp-sass": "^3.1.0"
   }

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>Title</title>
     <link href="style.css" rel="stylesheet">
-    <script type="text/javascript" src="../bower_components/jquery/src/jquery.js"></script>
+    <script src="scripts.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 </head>
 <body>

--- a/src/js/js.js
+++ b/src/js/js.js
@@ -1,7 +1,6 @@
 /**
  * Created by cbellmann on 26.01.17.
  */
-&importScripts(../../$code);
 
 $(document).ready(function(){
     $('.slider').slider();


### PR DESCRIPTION
Durch diese Änderung wird automatisch eine Datei `dist/scripts.js` von Gulp generiert, in der…

- jQuery enthalten ist (`bower/components/jquery/dist/jquery.min.js`),
- Materialize enthalten ist (`bower_components/materialize/dist/js/materialize.min.js`),
- alle `*.js` Dateien in deinem `src/` Verzeichnis enthalten sind für eigenen Code.

Weitere Erklärungen unten i Code.