### PR TITLE
Automatically copy fonts and images to dist folder

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,10 +10,10 @@ gulp.task('sass', function () {
         .pipe(browserSync.stream());
 });
 
-gulp.task('watch', ['sass', 'html', 'browser-sync'], function () {
+gulp.task('watch', ['sass', 'html', 'static', 'browser-sync'], function () {
     gulp.watch(['./src/**/*.scss'], ['sass']);
     gulp.watch(['./src/*.html'], ['html']);
-
+    gulp.watch(['./src/img/**'], ['static']);
 });
 
 gulp.task('html', function () {
@@ -22,6 +22,13 @@ gulp.task('html', function () {
         .pipe(gulp.dest('dist'))
         .pipe(browserSync.stream());
 });
+
+gulp.task('static', function () {
+    gulp.src('./bower_components/materialize/dist/fonts/**')
+        .pipe(gulp.dest('dist/fonts'));
+    gulp.src('./src/img/**')
+        .pipe(gulp.dest('dist/img'));
+})
 
 gulp.task('browser-sync', function() {
     browserSync.init({


### PR DESCRIPTION
Die Änderung macht folgendes:

- Kopiert alle Dateien von `bower_assets/materialize/dist/fonts` nach `dist/fonts`, dadurch stimmen automatisch auch schon die Verweise auf die Schriftarten und sie werden richtig eingebunden.
- Kopiert alle Dateien von `src/img` nach `dist/img`. Du solltst also Bilder immer im `src/img` ablegen und mit `src="img/foo.png"` einbinden.